### PR TITLE
Move TimeTracking module to services

### DIFF
--- a/app/services/time_tracking/providers/base.rb
+++ b/app/services/time_tracking/providers/base.rb
@@ -1,5 +1,5 @@
 module TimeTracking
-  module Services
+  module Providers
     class Base
       def get(path, params)
         response = @connection.get path, params

--- a/app/services/time_tracking/providers/harvest.rb
+++ b/app/services/time_tracking/providers/harvest.rb
@@ -1,5 +1,5 @@
 module TimeTracking
-  module Services
+  module Providers
     class Harvest < Base
       def project_total_time(project)
         raise "not implemented yet"

--- a/app/services/time_tracking/providers/toggl.rb
+++ b/app/services/time_tracking/providers/toggl.rb
@@ -1,5 +1,5 @@
 module TimeTracking
-  module Services
+  module Providers
     class Toggl < Base
       def initialize
         @connection = Faraday.new(:url => 'https://toggl.com/reports/api/v2') do |faraday|

--- a/app/services/time_tracking/tracker.rb
+++ b/app/services/time_tracking/tracker.rb
@@ -1,12 +1,11 @@
-# TODO: Move the whole module to /app/services
 module TimeTracking
   class Tracker
     delegate :project_tracked_time, to: :@wrapper
 
     def initialize(service)
       case service 
-        when 'toggl' then @wrapper = TimeTracking::Services::Toggl.new
-        when 'harvest' then @wrapper = TimeTracking::Services::Harvest.new   
+        when 'toggl' then @wrapper = TimeTracking::Providers::Toggl.new
+        when 'harvest' then @wrapper = TimeTracking::Providers::Harvest.new   
         else raise "Invalid tracking service"
       end
     end


### PR DESCRIPTION
- TimeTracking module moved from /models to /services
- TimeTracking::Services renamed to TimeTracking::Providers
